### PR TITLE
add set authority instruction

### DIFF
--- a/token/ctoken/js/src/index.ts
+++ b/token/ctoken/js/src/index.ts
@@ -129,6 +129,7 @@ enum InstructionVariant {
     ChangeLimit,
     Bridge,
     Settle,
+    TransferTokenAuthority,
 }
 
 class ConfigPayload extends Assignable {}
@@ -238,6 +239,17 @@ const ChangeLimitPayloadSchema = new Map([
                 ['max', 'u64'],
                 ['min', 'u64'],
             ],
+        },
+    ],
+]);
+
+class TransferTokenAuthorityPayload extends Assignable {}
+const TransferTokenAuthorityPayloadSchema = new Map([
+    [
+        TransferTokenAuthorityPayload,
+        {
+            kind: 'struct',
+            fields: [['id', 'u8']],
         },
     ],
 ]);
@@ -565,6 +577,39 @@ export class CToken {
         });
     }
 
+    static transferTokenAuthorityInstruction(
+        cToken: PublicKey,
+        owner: PublicKey,
+        tokenAuthority: PublicKey,
+        newTokenAuthority: PublicKey,
+        tokenMint: PublicKey,
+        tokenProgramId: PublicKey,
+        config: PublicKey,
+        cTokenProgramId: PublicKey,
+    ): TransactionInstruction {
+        const keys = [
+            {pubkey: cToken, isSigner: false, isWritable: false},
+            {pubkey: owner, isSigner: true, isWritable: false},
+            {pubkey: tokenAuthority, isSigner: false, isWritable: false},
+            {pubkey: newTokenAuthority, isSigner: false, isWritable: false},
+            {pubkey: tokenMint, isSigner: false, isWritable: true},
+            {pubkey: tokenProgramId, isSigner: false, isWritable: false},
+            {pubkey: config, isSigner: false, isWritable: false},
+        ];
+
+        const data = new TransferTokenAuthorityPayload({
+            id: InstructionVariant.TransferTokenAuthority,
+        });
+
+        return new TransactionInstruction({
+            keys,
+            programId: cTokenProgramId,
+            data: Buffer.from(
+                borsh.serialize(TransferTokenAuthorityPayloadSchema, data),
+            ),
+        });
+    }
+
     static async createCToken(
         connection: Connection,
         cToken: Keypair,
@@ -768,6 +813,37 @@ export class CToken {
                 ),
             ),
             [payer],
+            confirmOptions,
+        );
+    }
+
+    static async transferTokenAuthority(
+        connection: Connection,
+        cToken: PublicKey,
+        tokenAuthority: PublicKey,
+        newTokenAuthority: PublicKey,
+        tokenMint: PublicKey,
+        tokenProgramId: PublicKey,
+        config: PublicKey,
+        owner: Keypair,
+        cTokenProgramId: PublicKey,
+        confirmOptions?: ConfirmOptions,
+    ): Promise<TransactionSignature> {
+        return await sendAndConfirmTransaction(
+            connection,
+            new Transaction().add(
+                CToken.transferTokenAuthorityInstruction(
+                    cToken,
+                    owner.publicKey,
+                    tokenAuthority,
+                    newTokenAuthority,
+                    tokenMint,
+                    tokenProgramId,
+                    config,
+                    cTokenProgramId,
+                ),
+            ),
+            [owner],
             confirmOptions,
         );
     }

--- a/token/ctoken/js/test/set-authority.ts
+++ b/token/ctoken/js/test/set-authority.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import {PublicKey, Keypair, Connection} from '@solana/web3.js';
+import {TOKEN_PROGRAM_ID} from '@solana/spl-token';
+// import * as borsh from 'borsh';
+import {CToken, cTokenAccount, cTokenAccountSchema} from '../src';
+
+async function main() {
+    const rpc = `${process.env.SOLANA_RPC_URL}`;
+
+    const secret = JSON.parse(
+        fs.readFileSync(`${process.env.PRIVATE_KEY_PATH}`).toString(),
+    ) as number[];
+    const secretKey = Uint8Array.from(secret);
+    const payer = Keypair.fromSecretKey(secretKey);
+    const connection = new Connection(rpc, 'confirmed');
+
+    const cToken = new PublicKey(`${process.env.C_TOKEN}`);
+    const config = new PublicKey(`${process.env.CONFIG}`);
+    const cTokenProgramId = new PublicKey(`${process.env.C_TOKEN_PROGRAM_ID}`);
+    const tokenMint = new PublicKey(`${process.env.TOKEN_MINT}`);
+
+    // Find the current PDA authority
+    const [tokenAuthority, _bumpSeed] = PublicKey.findProgramAddressSync(
+        [cToken.toBuffer()],
+        cTokenProgramId,
+    );
+
+    // Create a new authority - reading from environment variable
+    const newTokenAuthority = new PublicKey(
+        `${process.env.NEW_TOKEN_AUTHORITY}`,
+    );
+
+    console.log(`Current token authority: ${tokenAuthority.toBase58()}`);
+    console.log(`New token authority: ${newTokenAuthority.toBase58()}`);
+
+    // Transfer token authority
+    const signature = await CToken.transferTokenAuthority(
+        connection,
+        cToken,
+        tokenAuthority,
+        newTokenAuthority,
+        tokenMint,
+        TOKEN_PROGRAM_ID,
+        config,
+        payer, // owner
+        cTokenProgramId,
+    );
+
+    console.log(`Authority transfer transaction: ${signature}`);
+    console.log(
+        `Successfully transferred token authority from ${tokenAuthority.toBase58()} to ${newTokenAuthority.toBase58()}`,
+    );
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/token/ctoken/program/src/instruction.rs
+++ b/token/ctoken/program/src/instruction.rs
@@ -36,6 +36,7 @@ pub enum CTokenInstruction {
     Settle {
         amount: u64,
     },
+    TransferTokenAuthority,
 }
 
 pub fn settle(

--- a/token/ctoken/program/src/processor.rs
+++ b/token/ctoken/program/src/processor.rs
@@ -18,6 +18,7 @@ use spl_token_2022::{
     check_spl_token_program_account,
     error::TokenError,
     extension::StateWithExtensions,
+    instruction::AuthorityType,
     state::{Account, Mint},
 };
 
@@ -154,6 +155,30 @@ impl Processor {
         )
     }
 
+    /// Issue a spl_token `SetAuthority` instruction.
+    pub fn token_set_authority<'a>(
+        c_token: &Pubkey,
+        token_program: AccountInfo<'a>,
+        mint: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        new_authority: &Pubkey,
+        bump_seed: u8,
+    ) -> Result<(), ProgramError> {
+        let c_token_bytes = c_token.to_bytes();
+        let authority_signature_seeds = [&c_token_bytes[..32], &[bump_seed]];
+        let signers = &[&authority_signature_seeds[..]];
+        let ix = spl_token_2022::instruction::set_authority(
+            token_program.key,
+            mint.key,
+            Some(new_authority),
+            AuthorityType::MintTokens,
+            authority.key,
+            &[],
+        )?;
+
+        invoke_signed_wrapper::<TokenError>(&ix, &[mint, authority, token_program], signers)
+    }
+
     pub fn authority_id(
         program_id: &Pubkey,
         my_info: &Pubkey,
@@ -207,6 +232,68 @@ impl Processor {
         config.serialize(&mut *config_info.data.borrow_mut())?;
 
         msg!("Owner change to {}", new_owner_info.key);
+
+        Ok(())
+    }
+
+    pub fn process_transfer_token_authority(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+
+        let c_token_info = next_account_info(account_info_iter)?;
+        let owner_info = next_account_info(account_info_iter)?;
+        let token_authority_info = next_account_info(account_info_iter)?;
+        let new_token_authority_info = next_account_info(account_info_iter)?;
+        let token_mint_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+        let config_info = next_account_info(account_info_iter)?;
+
+        if config_info.owner != program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+        if c_token_info.owner != program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
+        let config = Config::try_from_slice(&config_info.data.borrow())?;
+        if !owner_info.is_signer || *owner_info.key != config.owner {
+            return Err(CTokenError::InvalidOwner.into());
+        }
+
+        let c_token = CToken::try_from_slice(&c_token_info.data.borrow())?;
+        if c_token.config != *config_info.key {
+            return Err(CTokenError::InvalidConfig.into());
+        }
+        if token_program_info.key != &c_token.token_program_id {
+            return Err(CTokenError::InvalidInput.into());
+        }
+        if c_token.token_mint != *token_mint_info.key {
+            return Err(CTokenError::InvalidMint.into());
+        }
+        if c_token.destination != 0 {
+            return Err(CTokenError::InvalidToken.into());
+        }
+        if *token_authority_info.key
+            != Self::authority_id(program_id, c_token_info.key, c_token.bump_seed)?
+        {
+            return Err(CTokenError::InvalidProgramAddress.into());
+        }
+        Self::token_set_authority(
+            c_token_info.key,
+            token_program_info.clone(),
+            token_mint_info.clone(),
+            token_authority_info.clone(),
+            new_token_authority_info.key,
+            c_token.bump_seed,
+        )?;
+
+        msg!(
+            "Transfer the authority of token {} to {}",
+            token_mint_info.key,
+            new_token_authority_info.key,
+        );
 
         Ok(())
     }
@@ -594,6 +681,9 @@ impl Processor {
             } => Processor::process_bridge(program_id, accounts, amount, recipient, &payload),
             CTokenInstruction::Settle { amount } => {
                 Processor::process_settle(program_id, accounts, amount)
+            }
+            CTokenInstruction::TransferTokenAuthority => {
+                Processor::process_transfer_token_authority(program_id, accounts)
             }
         }
     }

--- a/token/rust-toolchain.toml
+++ b/token/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.85.1"


### PR DESCRIPTION
The PR is to enable program owner to transfer token authority to the external addr.
The testing passed
```
// before
spl-token display 9ya6GpSaPCajPQpvzkL8u73n2BXqHzVwNkaFbjKK3E2Q

SPL Token Mint
  Address: 9ya6GpSaPCajPQpvzkL8u73n2BXqHzVwNkaFbjKK3E2Q
  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Supply: 1000000000000000
  Decimals: 9
  Mint authority: CNRzKAPAFxjfPVSZgAMdy1zmxqjcXpWzNNk212FPp8yo
  Freeze authority: (not set)

// after
spl-token display 9ya6GpSaPCajPQpvzkL8u73n2BXqHzVwNkaFbjKK3E2Q

SPL Token Mint
  Address: 9ya6GpSaPCajPQpvzkL8u73n2BXqHzVwNkaFbjKK3E2Q
  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Supply: 1000000000000000
  Decimals: 9
  Mint authority: xxx
  Freeze authority: (not set)
```