### PR TITLE
security: bump lodash to 4.18.0+ (CVE-2026-4800)

### DIFF
--- a/token/ctoken/js/package.json
+++ b/token/ctoken/js/package.json
@@ -50,5 +50,8 @@
         "start-server-and-test": "^2.0.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.4"
+    },
+    "resolutions": {
+        "lodash": "^4.18.0"
     }
 }

--- a/token/ctoken/js/yarn.lock
+++ b/token/ctoken/js/yarn.lock
@@ -2007,10 +2007,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.21, lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@4.1.0:
   version "4.1.0"

--- a/token/example/js/package.json
+++ b/token/example/js/package.json
@@ -28,5 +28,8 @@
         "start-server-and-test": "^2.0.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.4"
+    },
+    "resolutions": {
+        "lodash": "^4.18.0"
     }
 }

--- a/token/example/js/yarn.lock
+++ b/token/example/js/yarn.lock
@@ -1862,10 +1862,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.21, lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
- Fixes high-severity lodash code injection via `_.template` (CVE-2026-4800 / [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc))
- Adds `resolutions.lodash: ^4.18.0` to both `token/ctoken/js/package.json` and `token/example/js/package.json`
- Regenerates both yarn.lock files — lodash now resolves to 4.18.1

## Test plan
- [ ] `yarn install` succeeds in both `token/ctoken/js` and `token/example/js`
- [ ] `yarn build` still succeeds in `token/ctoken/js`
- [ ] `yarn test:js` still passes in `token/ctoken/js`